### PR TITLE
fix: Syntax errors of previous commits

### DIFF
--- a/src/model/Model.lua
+++ b/src/model/Model.lua
@@ -93,7 +93,7 @@ end
 function Model:loadSection(model, cfg, sec)
     local i = 1
     while true do
-        if ~self:loadAssertion(model, cfg, sec, sec..self:getKeySuffix(i)) then
+        if not self:loadAssertion(model, cfg, sec, sec..self:getKeySuffix(i)) then
             break;
         else
             i = i + 1

--- a/src/model/Policy.lua
+++ b/src/model/Policy.lua
@@ -32,7 +32,7 @@ end
      * @param rm the role manager.
 ]]
 function Policy:buildRoleLinks(rm)
-    if ~self.model["g"] then
+    if not self.model["g"] then
         for _, v in pairs(self.model["g"]) do
             v:buildRoleLinks(rm)
         end
@@ -44,13 +44,13 @@ end
 ]]
 function Policy:printPolicy()
     Util.logPrint("Policy:")
-    if ~self.model["p"] then
+    if not self.model["p"] then
         for k, ast in pairs(self.model["p"]) do
             Util.logPrint(k .. ":" .. ast.value .. ":" .. ast.policy)
         end
     end
 
-    if ~self.model["g"] then
+    if not self.model["g"] then
         for k, ast in pairs(self.model["g"]) do
             Util.logPrint(k .. ":" .. ast.value .. ":" .. ast.policy)
         end
@@ -70,13 +70,13 @@ end
      * clearPolicy clears all current policy.
 ]]
 function Policy:clearPolicy()
-    if ~self.model["p"] then
+    if not self.model["p"] then
         for _, v in pairs(self.model["p"]) do
             v.policy = nil
         end
     end
 
-    if ~self.model["g"] then
+    if not self.model["g"] then
         for _, v in pairs(self.model["g"]) do
             v.policy = nil
         end
@@ -150,7 +150,7 @@ end
      * @return succeeds or not.
 ]]
 function Policy:addPolicy(sec, ptype, rule)
-    if ~self:hasPolicy(sec, ptype, rule) then
+    if not self:hasPolicy(sec, ptype, rule) then
         self.model[sec][ptype].policy[#policy + 1] = rule
         return true
     end

--- a/src/util/Util.lua
+++ b/src/util/Util.lua
@@ -96,7 +96,7 @@ function Util.array2DEquals(a, b)
         return false
     end
     for i = 1, #a do
-        if ~Util.arrayEquals(a[i], b[i]) then
+        if not Util.arrayEquals(a[i], b[i]) then
             return false
         end
     end


### PR DESCRIPTION
The '~' (tilde) operator gives error when used as "not equal to" conditional. Instead we can use the "not" logical operator in Lua which fixes the error.