### PR TITLE
feat: Added eval and 'in' of matcher functionality with basic tests for it

### DIFF
--- a/examples/in_matcher_model.conf
+++ b/examples/in_matcher_model.conf
@@ -1,0 +1,11 @@
+[request_definition]
+r = sub, obj, act
+
+[policy_definition]
+p = sub, obj
+
+[policy_effect]
+e = some(where (p.eft == allow))
+
+[matchers]
+m = r.sub == p.sub && r.obj == p.obj && ( r.act in ("read", "write") )

--- a/examples/in_matcher_policy.csv
+++ b/examples/in_matcher_policy.csv
@@ -1,0 +1,2 @@
+p, alice, data1
+p, bob, data2

--- a/spec/main/enforcer_spec.lua
+++ b/spec/main/enforcer_spec.lua
@@ -45,4 +45,52 @@ describe("Enforcer tests", function ()
         local e = Enforcer:new(model, policy)
         assert.is.True(e:enforce("cathy", "/cathy_data", "GET"))
     end)
+
+    it("abac sub_rule test", function ()
+        local model  = path .. "/examples/abac_rule_model.conf"
+        local policy  = path .. "/examples/abac_rule_policy.csv"
+        local sub1 = {
+            Name = "Alice",
+            Age = 16
+        }
+        local sub2 = {
+            Name = "Bob",
+            Age = 20
+        }
+        local sub3 = {
+            Name = "Alice",
+            Age = 65
+        }
+        local e = Enforcer:new(model, policy)
+        assert.is.False(e:enforce(sub1, "/data1", "read"))
+        assert.is.False(e:enforce(sub1, "/data2", "read"))
+        assert.is.False(e:enforce(sub1, "/data1", "write"))
+        assert.is.True(e:enforce(sub1, "/data2", "write"))
+
+        assert.is.True(e:enforce(sub2, "/data1", "read"))
+        assert.is.False(e:enforce(sub2, "/data2", "read"))
+        assert.is.False(e:enforce(sub2, "/data1", "write"))
+        assert.is.True(e:enforce(sub2, "/data2", "write"))
+
+        assert.is.False(e:enforce(sub3, "/data1", "write"))
+        assert.is.True(e:enforce(sub3, "/data1", "read"))
+        assert.is.False(e:enforce(sub3, "/data2", "read"))
+        assert.is.True(e:enforce(sub1, "/data2", "write"))
+    end)
+
+    it("in of matcher test", function ()
+        local model  = path .. "/examples/in_matcher_model.conf"
+        local policy  = path .. "/examples/in_matcher_policy.csv"
+
+        local e = Enforcer:new(model, policy)
+        assert.is.True(e:enforce("alice", "data1", "read"))
+        assert.is.True(e:enforce("alice", "data1", "write"))
+        assert.is.False(e:enforce("alice", "data2", "read"))
+        assert.is.False(e:enforce("alice", "data2", "write"))
+
+        assert.is.False(e:enforce("bob", "data1", "read"))
+        assert.is.False(e:enforce("bob", "data1", "write"))
+        assert.is.True(e:enforce("bob", "data2", "read"))
+        assert.is.True(e:enforce("bob", "data2", "write"))
+    end)
 end)

--- a/spec/main/enforcer_spec.lua
+++ b/spec/main/enforcer_spec.lua
@@ -93,4 +93,33 @@ describe("Enforcer tests", function ()
         assert.is.True(e:enforce("bob", "data2", "read"))
         assert.is.True(e:enforce("bob", "data2", "write"))
     end)
+
+    it("explicit priority test", function ()
+        local model  = path .. "/examples/priority_model_explicit.conf"
+        local policy  = path .. "/examples/priority_policy_explicit.csv"
+
+        local e = Enforcer:new(model, policy)
+        assert.is.True(e:enforce("alice", "data1", "write"))
+        assert.is.True(e:enforce("alice", "data1", "read"))
+        assert.is.False(e:enforce("bob", "data2", "read"))
+        assert.is.True(e:enforce("bob", "data2", "write"))
+        assert.is.False(e:enforce("data1_deny_group", "data1", "read"))
+        assert.is.False(e:enforce("data1_deny_group", "data1", "write"))
+        assert.is.True(e:enforce("data2_allow_group", "data2", "read"))
+        assert.is.True(e:enforce("data2_allow_group", "data2", "write"))
+
+        local rule = {"1", "bob", "data2", "write", "deny"}
+        e.model:addPolicy("p", "p", rule)
+        e.model:sortPoliciesByPriority()
+        e.model:printPolicy()
+
+        assert.is.True(e:enforce("alice", "data1", "write"))
+        assert.is.True(e:enforce("alice", "data1", "read"))
+        assert.is.False(e:enforce("bob", "data2", "read"))
+        assert.is.False(e:enforce("bob", "data2", "write"))
+        assert.is.False(e:enforce("data1_deny_group", "data1", "read"))
+        assert.is.False(e:enforce("data1_deny_group", "data1", "write"))
+        assert.is.True(e:enforce("data2_allow_group", "data2", "read"))
+        assert.is.True(e:enforce("data2_allow_group", "data2", "write"))
+    end)
 end)

--- a/src/main/CoreEnforcer.lua
+++ b/src/main/CoreEnforcer.lua
@@ -354,7 +354,10 @@ function CoreEnforcer:enforce(...)
                 context[v] = pvals[k]
             end
 
-            local res, err = luaxp.evaluate(expString, context)
+            local tExpString = Util.findAndReplaceEval(expString, context)
+            tExpString = Util.replaceInOfMatcher(tExpString)
+            
+            local res, err = luaxp.evaluate(tExpString, context)
             if err then
                 error("evaluation error: " .. err.message)
             end

--- a/src/main/CoreEnforcer.lua
+++ b/src/main/CoreEnforcer.lua
@@ -208,8 +208,11 @@ end
 ]]
 function CoreEnforcer:loadPolicy()
     self.model:clearPolicy()
-    self.adapter:loadPolicy(self.model);
+    self.adapter:loadPolicy(self.model)
+
+    self.model:sortPoliciesByPriority()
     self.model:printPolicy()
+
     if self.autoBuildRoleLinks then
         self:buildRoleLinks()
     end

--- a/src/model/Model.lua
+++ b/src/model/Model.lua
@@ -182,4 +182,26 @@ function Model:printModel()
     end
 end
 
+-- sortPoliciesByPriority sorts policies by their priorities if 'priority' token exists
+function Model:sortPoliciesByPriority()
+     if not self.model["p"] then return end
+
+     for ptype, ast in pairs(self.model["p"]) do
+          local priorityIndex = 0
+          for inx, token in pairs(ast.tokens) do
+               if token == ptype .. "_priority" then
+                    priorityIndex = inx
+                    break
+               end
+          end
+          if priorityIndex == 0 then
+               return
+          end
+
+          table.sort(ast.policy, function (a, b)
+               return a[priorityIndex] < b[priorityIndex]
+          end)
+     end
+end
+
 return Model

--- a/src/persist/Adapter.lua
+++ b/src/persist/Adapter.lua
@@ -23,10 +23,7 @@ function loadPolicyLine(line, model)
          return
      end
  
-     local tokens = {}
-     for str in string.gmatch(line, '([^, ]+)') do
-         table.insert(tokens,str)
-     end
+     local tokens = Util.split(line, ",")
      local key = tokens[1]
      local sec = key:sub(1,1)
  


### PR DESCRIPTION
- The **eval** functionality was implemented.
- The **'in'** of matcher feature was implemented with an example model for it.
- There were some bugs in the previous implementation of `escapeAssertion` function where it replaced `r.` to `r_` in incorrect places, it was fixed.
- Added functionality for loading policies with explicit priority with test for it.

I will add full tests for CoreEnforcer in some days.