### PR TITLE
perf: Added benchmark test and limited expression compiling to once unless required

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,3 +77,40 @@ jobs:
         luacov-coveralls -i src -e .luarocks
       env:
         COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+  benchmark:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    
+    name: Benchmark
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up LuaJIT
+      uses: leafo/gh-actions-lua@v8.0.0
+      with:
+        luaVersion: "luajit"
+
+    - name: Set up luarocks
+      uses: leafo/gh-actions-luarocks@v4.0.0
+
+    - name: Install PCRE
+      run: |
+        sudo apt-get update
+        sudo apt-get install libpcre3 libpcre3-dev
+
+    - name: Install dependencies
+      run: |
+        luarocks install lualogging
+        luarocks install lrexlib-pcre
+        luarocks install luaposix
+        luarocks install luasocket
+        luarocks install busted
+        luarocks install busted-htest
+      
+    - name: Run Benchmark
+      run: |
+        busted bench.lua -o htest

--- a/bench.lua
+++ b/bench.lua
@@ -1,0 +1,271 @@
+local socket = require("socket")
+require("src.main.Enforcer")
+local path = os.getenv("PWD") or io.popen("cd"):read()
+
+local function rawEnforce(sub, obj, act)
+    local policy = {{"alice", "data1", "read"}, {"bob", "data2", "write"}}
+    for _, rule in pairs(policy) do
+        if rule[1] == sub and rule[2] == obj and rule[3] == act then
+            return true
+        end
+    end
+    return false
+end
+
+local function benchmarkRaw()
+    local x = socket.gettime()*1000
+    for i = 1, 10000 do
+        rawEnforce("alice", "data1", "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 10000
+end
+
+local function benchmarkBasicModel()
+    local e = Enforcer:new(path .. "/examples/basic_model.conf", path .. "/examples/basic_policy.csv")
+    e:enableLog(false)
+    local x = socket.gettime()*1000
+    for i = 1, 10000 do
+        _ = e:enforce("alice", "data1", "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 10000
+end
+
+local function benchmarkRBACModel()
+    local e = Enforcer:new(path .. "/examples/rbac_model.conf", path .. "/examples/rbac_policy.csv")
+    e:enableLog(false)
+    local x = socket.gettime()*1000
+    for i = 1, 10000 do
+        _ = e:enforce("alice", "data2", "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 10000
+end
+
+local function benchmarkRBACModelSmall()
+    local e = Enforcer:new(path .. "/examples/rbac_model.conf", path .. "/examples/empty_policy.csv")
+    e:enableLog(false)
+
+    local pPolicies = {}
+    -- 100 roles, 10 resources.
+    for i = 1, 100 do
+        table.insert(pPolicies, {"group"..tostring(i), "data"..tostring(i%10), "read"})
+    end
+
+    e:AddPolicies(pPolicies)
+
+    -- 1000 users.
+    local gPolicies = {}
+    for i = 1, 1000 do
+        table.insert(gPolicies, {"user"..tostring(i), "group"..tostring(i%10)})
+    end
+
+    e:AddGroupingPolicies(gPolicies)
+
+    local x = socket.gettime()*1000
+    for i = 1, 1000 do
+        _ = e:enforce("user501", "data9", "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 1000
+end
+
+local function benchmarkRBACModelMedium()
+    local e = Enforcer:new(path .. "/examples/rbac_model.conf", path .. "/examples/empty_policy.csv")
+    e:enableLog(false)
+
+    local pPolicies = {}
+    -- 1000 roles, 100 resources.
+    for i = 1, 1000 do
+        table.insert(pPolicies, {"group"..tostring(i), "data"..tostring(i%100), "read"})
+    end
+
+    e:AddPolicies(pPolicies)
+
+    local gPolicies = {}
+    -- 10000 users.
+    for i = 1, 10000 do
+        table.insert(gPolicies, {"user"..tostring(i), "group"..tostring(i%10)})
+    end
+
+    e:AddGroupingPolicies(gPolicies)
+
+    local x = socket.gettime()*1000
+    for i = 1, 100 do
+        _ = e:enforce("user5001", "data99", "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 100
+end
+
+local function benchmarkRBACModelLarge()
+    local e = Enforcer:new(path .. "/examples/rbac_model.conf", path .. "/examples/empty_policy.csv")
+    e:enableLog(false)
+
+    local pPolicies = {}
+    -- 10000 roles, 1000 resources.
+    for i = 1, 10000 do
+        table.insert(pPolicies, {"group"..tostring(i), "data"..tostring(i%1000), "read"})
+    end
+
+    e:AddPolicies(pPolicies)
+
+    local gPolicies = {}
+    -- 100000 users.
+    for i = 1, 100000 do
+        table.insert(gPolicies, {"user"..tostring(i), "group"..tostring(i%10)})
+    end
+
+    e:AddGroupingPolicies(gPolicies)
+
+    local x = socket.gettime()*1000
+    for i = 1, 10 do
+        _ = e:enforce("user50001", "data999", "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 10
+end
+
+local function benchmarkRBACModelWithResourceRoles()
+    local e = Enforcer:new(path .. "/examples/rbac_with_resource_roles_model.conf", path .. "/examples/rbac_with_resource_roles_policy.csv")
+    e:enableLog(false)
+    local x = socket.gettime()*1000
+    for i = 1, 1000 do
+        _ = e:enforce("alice", "data1", "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 1000
+end
+
+local function benchmarkRBACModelWithDomains()
+    local e = Enforcer:new(path .. "/examples/rbac_with_domains_model.conf", path .. "/examples/rbac_with_domains_policy.csv")
+    e:enableLog(false)
+    local x = socket.gettime()*1000
+    for i = 1, 1000 do
+        _ = e:enforce("alice", "domain1", "data1", "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 1000
+end
+
+local function benchmarkABACModel()
+    local e = Enforcer:new(path .. "/examples/abac_model.conf", path .. "/examples/empty_policy.csv")
+    e:enableLog(false)
+
+    local data1 = {["Name"] = "data1", ["Owner"] = "alice"}
+
+    local x = socket.gettime()*1000
+    for i = 1, 1000 do
+        _ = e:enforce("alice", data1, "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 1000
+end
+
+local function benchmarkKeyMatchModel()
+    local e = Enforcer:new(path .. "/examples/keymatch_model.conf", path .. "/examples/keymatch_policy.csv")
+    e:enableLog(false)
+    local x = socket.gettime()*1000
+    for i = 1, 1000 do
+        _ = e:enforce("alice", "/alice_data/resource1", "GET")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 1000
+end
+
+local function benchmarkRBACModelWithDeny()
+    local e = Enforcer:new(path .. "/examples/rbac_with_deny_model.conf", path .. "/examples/rbac_with_deny_policy.csv")
+    e:enableLog(false)
+    local x = socket.gettime()*1000
+    for i = 1, 1000 do
+        _ = e:enforce("alice", "data1", "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 1000
+end
+
+local function benchmarkPriorityModel()
+    local e = Enforcer:new(path .. "/examples/priority_model.conf", path .. "/examples/priority_policy.csv")
+    e:enableLog(false)
+    local x = socket.gettime()*1000
+    for i = 1, 1000 do
+        _ = e:enforce("alice", "data1", "read")
+    end
+    x = socket.gettime()*1000 - x
+    return x, 1000
+end
+
+local function runBenchmark()
+    local t, o
+    local time = {}
+    local ops = {}
+    local benchName = {}
+
+    t, o = benchmarkRaw()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "Raw")
+
+    t, o = benchmarkBasicModel()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "Basic Model")
+
+    t, o = benchmarkRBACModel()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "RBAC Model")
+
+    t, o = benchmarkRBACModelSmall()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "RBAC Model Small")
+
+    t, o = benchmarkRBACModelMedium()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "RBAC Model Medium")
+
+    t, o = benchmarkRBACModelLarge()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "RBAC Model Large")
+
+    t, o = benchmarkRBACModelWithResourceRoles()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "RBAC Model with Resources")
+
+    t, o = benchmarkRBACModelWithDomains()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "RBAC Model with Domains")
+
+    t, o = benchmarkABACModel()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "ABAC Model")
+
+    t, o = benchmarkKeyMatchModel()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "KeyMatch Model")
+
+    t, o = benchmarkRBACModelWithDeny()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "RBAC Model with Deny")
+
+    t, o = benchmarkPriorityModel()
+    table.insert(time, t)
+    table.insert(ops, o)
+    table.insert(benchName, "Priority Model")
+
+    print("Benchmark:")
+    for k, v in pairs(benchName) do
+        print(v .. ":", "\tTotal ops = " .. tostring(ops[k]), "\tTime per op = " .. string.format("%.4f ms", time[k]/ops[k]))
+    end
+end
+
+runBenchmark()

--- a/src/main/CoreEnforcer.lua
+++ b/src/main/CoreEnforcer.lua
@@ -370,6 +370,9 @@ function CoreEnforcer:enforceEx(...)
 
     local policyEffects = {}
 
+    expString = Util.replaceInOfMatcher(expString)
+    local compiledExpression = luaxp.compile(expString)
+
     if policyLen ~=0 then
         for i, pvals in pairs(self.model.model["p"]["p"].policy) do
             if #pTokens ~= #pvals then
@@ -388,9 +391,13 @@ function CoreEnforcer:enforceEx(...)
             end
 
             local tExpString = Util.findAndReplaceEval(expString, context)
-            tExpString = Util.replaceInOfMatcher(tExpString)
             
-            local res, err = luaxp.evaluate(tExpString, context)
+            local res, err
+            if tExpString == expString then
+                res, err = luaxp.run(compiledExpression, context)
+            else
+                res, err = luaxp.evaluate(tExpString, context)
+            end
             if err then
                 error("evaluation error: " .. err.message)
             end
@@ -434,11 +441,8 @@ function CoreEnforcer:enforceEx(...)
         for k, v in pairs(pTokens) do
             context[v] = ""
         end
-
-        local tExpString = expString
-        tExpString = Util.replaceInOfMatcher(tExpString)
             
-        local res, err = luaxp.evaluate(tExpString, context)
+        local res, err = luaxp.run(compiledExpression, context)
         if err then
             error("evaluation error: " .. err.message)
         end


### PR DESCRIPTION
This is the earlier benchmark (LuaJIT) from GitHub Actions:
```
Raw:		Total ops = 10000		Time per op = 0.0005 ms
Basic Model:		Total ops = 10000		Time per op = 0.1157 ms
RBAC Model:		Total ops = 10000		Time per op = 0.2935 ms
RBAC Model Small:		Total ops = 1000		Time per op = 6.3911 ms
RBAC Model Medium:		Total ops = 100		Time per op = 63.5531 ms
RBAC Model Large:		Total ops = 10		Time per op = 670.6526 ms
RBAC Model with Resources:		Total ops = 1000		Time per op = 0.3454 ms
RBAC Model with Domains:		Total ops = 1000		Time per op = 0.4186 ms
ABAC Model:		Total ops = 1000		Time per op = 0.0311 ms
KeyMatch Model:		Total ops = 1000		Time per op = 0.4127 ms
RBAC Model with Deny:		Total ops = 1000		Time per op = 0.3503 ms
Priority Model:		Total ops = 1000		Time per op = 0.4927 ms
```
This is the current one:
```
Raw:		Total ops = 10000		Time per op = 0.0005 ms
Basic Model:		Total ops = 10000		Time per op = 0.0786 ms
RBAC Model:		Total ops = 10000		Time per op = 0.1393 ms
RBAC Model Small:		Total ops = 1000		Time per op = 1.1131 ms
RBAC Model Medium:		Total ops = 100		Time per op = 11.4998 ms
RBAC Model Large:		Total ops = 10		Time per op = 127.0854 ms
RBAC Model with Resources:		Total ops = 1000		Time per op = 0.2428 ms
RBAC Model with Domains:		Total ops = 1000		Time per op = 0.2113 ms
ABAC Model:		Total ops = 1000		Time per op = 0.0484 ms
KeyMatch Model:		Total ops = 1000		Time per op = 0.1511 ms
RBAC Model with Deny:		Total ops = 1000		Time per op = 0.3070 ms
Priority Model:		Total ops = 1000		Time per op = 0.2016 ms
```