### PR TITLE
feat: Add code relates with policyMap

### DIFF
--- a/src/model/Assertion.lua
+++ b/src/model/Assertion.lua
@@ -26,7 +26,7 @@ function Assertion:new()
     o.tokens = {}
     o.policy = {}
     o.RM = {}
-    
+    o.policyMap={}
     setmetatable(o,self)
     self.__index = self
     return o

--- a/src/model/Model.lua
+++ b/src/model/Model.lua
@@ -75,7 +75,7 @@ function Model:addDef(sec, key, value)
     self.model[sec][key] = Assertion:new()
     self.model[sec][key].key = key
     self.model[sec][key].value = value
-
+    self.model[sec][key].policyMap={}
     if sec == "r" or sec == "p" then
         self.model[sec][key].tokens = Util.splitCommaDelimited(self.model[sec][key].value)
         for k, v in pairs(self.model[sec][key].tokens) do
@@ -227,6 +227,9 @@ function Model:sortPoliciesByPriority()
         table.sort(ast.policy, function (a, b)
         return a[priorityIndex] < b[priorityIndex]
         end)
+        for i,policy in pairs(ast.policy) do
+            ast.policyMap[table.concat(policy,",")]=i
+        end
      end
 end
 

--- a/src/util/Util.lua
+++ b/src/util/Util.lua
@@ -270,11 +270,19 @@ function Util.loadPolicyLine(line, model)
     end
 
     model.model[sec][key].policy = model.model[sec][key].policy or {}
+    model.model[sec][key].policyMap={}
+    for i,policy in pairs(model.model[sec][key].policy) do
+        model.model[sec][key].policyMap[table.concat(policy,",")]=i
+    end
     local rules = {}
     for i = 2, #tokens do
         table.insert(rules, tokens[i])
     end
     table.insert(model.model[sec][key].policy, rules)
+    model.model[sec][key].policyMap={}
+    for i,policy in pairs(model.model[sec][key].policy) do
+        model.model[sec][key].policyMap[table.concat(policy,",")]=i
+    end
 end
 
 

--- a/tests/model/model_spec.lua
+++ b/tests/model/model_spec.lua
@@ -1,4 +1,4 @@
---Copyright 2021 The casbin Authors. All Rights Reserved.
+         --Copyright 2021 The casbin Authors. All Rights Reserved.
 --
 --Licensed under the Apache License, Version 2.0 (the "License");
 --you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ describe("model tests", function()
 
         assert.are.same(m:removePoliciesWithEffected("p", "p", rules),rules)
         assert.is.False(m:hasPolicies("p", "p", rules))
-        assert.is.False(m:removePolicy("p", "p", rules))
+        assert.is.False(m:removePolicy("p", "p", rules[1]))
     end)
 
     it("test addRolePolicy", function ()


### PR DESCRIPTION
Add code relates with policyMap, now function hasPolicy can use variable policyMap to tell whether a policy is exist or not  directly and functions about policy can now find policy’s key directly by policyMap.
Signed-off-by: Edmond <edomondja@gmail.com>