### PR TITLE
feat: Added function to create new Enforcer from text

### DIFF
--- a/src/model/Model.lua
+++ b/src/model/Model.lua
@@ -174,6 +174,8 @@ function Model:toText()
             tokenPatterns[token]=string.gsub (string.gsub (token,"^p_","p."),"^r_","r.")
         end
     end
+    tokenPatterns["p_eft"] = "p.eft"
+
     local s=""
     local writeString=function(sec)
         local result=""
@@ -182,7 +184,7 @@ function Model:toText()
             for tokenPattern,newToken in pairs(tokenPatterns) do
                 value=string.gsub(value,tokenPattern,newToken)
             end
-            result=result..sec.."="..value.."\n"
+            result=result..sec.." = "..value.."\n"
         end
         return result
     end
@@ -190,7 +192,7 @@ function Model:toText()
     if self.model["g"] then
         s=s.."[role_definition]\n"
         for ptype,_ in pairs(self.model["g"]) do
-            s=s..ptype.."="..self.model["g"][ptype].value.."\n"
+            s=s..ptype.." = "..self.model["g"][ptype].value.."\n"
         end
     end
     s=s.."[policy_effect]\n"..writeString("e").."[matchers]\n"..writeString("m")

--- a/tests/model/model_spec.lua
+++ b/tests/model/model_spec.lua
@@ -222,7 +222,7 @@ describe("model tests", function()
         local m = Model:new()
         m:loadModel(basic_path)
         local res = m:toText()
-        local saveText="[request_definition]\nr=sub, obj, act\n[policy_definition]\np=sub, obj, act\n[policy_effect]\ne=some(where (p_eft == allow))\n[matchers]\nm=r.sub == p.sub && r.obj == p.obj && r.act == p.act\n"
+        local saveText="[request_definition]\nr = sub, obj, act\n[policy_definition]\np = sub, obj, act\n[policy_effect]\ne = some(where (p.eft == allow))\n[matchers]\nm = r.sub == p.sub && r.obj == p.obj && r.act == p.act\n"
         assert.are.same(saveText, res)
 
     end)


### PR DESCRIPTION
This is in context with the Casbin plugin for APISIX where we will need to create an enforcer from model and policy text (without files). I think adding this function in our core module would be better than creating the same in the plugin.