### PR TITLE
perf: replace eval func will not run for non-eval matcher

### DIFF
--- a/src/main/CoreEnforcer.lua
+++ b/src/main/CoreEnforcer.lua
@@ -404,6 +404,7 @@ function CoreEnforcer:enforceEx(...)
     end
 
     local expString = self.model.model["m"]["m"].value
+    local hasEval = Util.hasEval(expString)
 
     local policyLen = #self.model.model["p"]["p"].policy
 
@@ -429,8 +430,11 @@ function CoreEnforcer:enforceEx(...)
                 context[v] = pvals[k]
             end
 
-            local tExpString = Util.findAndReplaceEval(expString, context)
-            
+            local tExpString = expString
+            if hasEval then
+                tExpString = Util.findAndReplaceEval(expString, context)
+            end
+
             local res, err
             if tExpString == expString then
                 res, err = luaxp.run(compiledExpression, context)

--- a/src/util/Util.lua
+++ b/src/util/Util.lua
@@ -166,6 +166,11 @@ function Util.areTablesSame(a, b)
     return true
 end
 
+-- checks if the matcher string has eval(...)
+function Util.hasEval(str)
+    return string.find(str, "eval%((.-)%)")
+end
+
 -- finds if string has eval and replaces eval(...) with its value so that it can be evaluated by luaxp
 function Util.findAndReplaceEval(str, context)
     local m = string.gsub(str, "eval%((.-)%)", function (s)


### PR DESCRIPTION
This will improve performance since the function used to run every time even in the case of non-eval matcher.