### PR TITLE
fix: added built-in functions to FunctionMap

### DIFF
--- a/src/model/FunctionMap.lua
+++ b/src/model/FunctionMap.lua
@@ -18,8 +18,11 @@ local FunctionMap = {
     ["keyMatch"] = BuiltInFunctions.keyMatchFunc,
     ["keyGet"] = BuiltInFunctions.keyGetFunc,
     ["keyMatch2"] = BuiltInFunctions.keyMatch2Func,
+    ["keyGet2"] = BuiltInFunctions.keyGet2Func,
     ["keyMatch3"] = BuiltInFunctions.keyMatch3Func,
+    ["keyMatch4"] = BuiltInFunctions.keyMatch4Func,
     ["regexMatch"] = BuiltInFunctions.regexMatchFunc,
+    ["IPMatch"] = BuiltInFunctions.IPMatchFunc,
     ["globMatch"] = BuiltInFunctions.globMatch
 }
 


### PR DESCRIPTION
This adds the recently added built-in functions to FunctionMap so that they can be used in the matcher.