### PR TITLE
perf: remove redundant reinitialization of policyMap

### DIFF
--- a/src/persist/Adapter.lua
+++ b/src/persist/Adapter.lua
@@ -24,13 +24,13 @@ function Adapter.loadPolicyLine(line, model)
         return
     end
 
-    if line:sub(1,1) == "#" then
+    if line:sub(1, 1) == "#" then
         return
     end
 
     local tokens = Util.split(line, ",")
     local key = tokens[1]
-    local sec = key:sub(1,1)
+    local sec = key:sub(1, 1)
 
     if model.model[sec] == nil then
         return
@@ -40,19 +40,12 @@ function Adapter.loadPolicyLine(line, model)
     end
 
     model.model[sec][key].policy = model.model[sec][key].policy or {}
-    model.model[sec][key].policyMap={}
-    for i,policy in pairs(model.model[sec][key].policy) do
-        model.model[sec][key].policyMap[table.concat(policy,",")]=i
-    end
     local rules = {}
     for i = 2, #tokens do
         table.insert(rules, tokens[i])
     end
     table.insert(model.model[sec][key].policy, rules)
-    model.model[sec][key].policyMap={}
-    for i,policy in pairs(model.model[sec][key].policy) do
-        model.model[sec][key].policyMap[table.concat(policy,",")]=i
-    end
+    model.model[sec][key].policyMap[table.concat(rules, ",")] = #model.model[sec][key].policy
 end
 
 --[[
@@ -81,7 +74,7 @@ end
      * @param ptype the policy type, "p", "p2", .. or "g", "g2", ..
      * @param rule the rule, like (sub, obj, act).
 ]]
-function Adapter:addPolicy(sec,ptype,rule)
+function Adapter:addPolicy(sec, ptype, rule)
 
 end
 
@@ -93,7 +86,7 @@ end
      * @param ptype the policy type, "p", "p2", .. or "g", "g2", ..
      * @param rule the rule, like (sub, obj, act).
 ]]
-function Adapter:removePolicy(sec,ptype,rule)
+function Adapter:removePolicy(sec, ptype, rule)
 
 end
 


### PR DESCRIPTION
In reference with #136. 

The `policyMap` is being reinitialized entirely from the `policy` at every line load, instead we can set the mapping for every line as it is being loaded.

Running a benchmark script to load a medium sized model (1k policies and 10k grouping policies) from file:
```
(current)
Time = 37181.17 ms
```

```
(after this change)
Time = 92.94 ms
```