### PR TITLE
fix: improve performance by removing non-essential but resource-intensive logging

### DIFF
--- a/src/main/CoreEnforcer.lua
+++ b/src/main/CoreEnforcer.lua
@@ -79,7 +79,7 @@ function CoreEnforcer:newEnforcerFromText(modelText, policyText)
     end)
 
     o.model:sortPoliciesByPriority()
-    o.model:printPolicy()
+    -- o.model:printPolicy()
 
     if o.autoBuildRoleLinks then
         o:buildRoleLinks()

--- a/src/main/CoreEnforcer.lua
+++ b/src/main/CoreEnforcer.lua
@@ -74,12 +74,12 @@ function CoreEnforcer:newEnforcerFromText(modelText, policyText)
     o:initialize()
 
     o.model:clearPolicy()
+ 
 	string.gsub(policyText, "[^\r\n]+", function(line)
         o.adapter.loadPolicyLine(Util.trim(line), o.model)
     end)
 
     o.model:sortPoliciesByPriority()
-    -- o.model:printPolicy()
 
     if o.autoBuildRoleLinks then
         o:buildRoleLinks()


### PR DESCRIPTION
fix part of https://github.com/casbin/lua-casbin/issues/136

Thank you very much for [a previous pr](https://github.com/casbin/lua-casbin/pull/137) for performance optimization.

However, in actual use, it is found that when the policy exceeds 20k lines, it still takes about 4 seconds for the API to load for the first time.

After digging deeper, I found out that it was because of `o.model:printPolicy()` after load policy, so I removed it. I think we already has a detailed log when [enforce](https://github.com/casbin/lua-casbin/blob/master/src/main/CoreEnforcer.lua#L509-L528
), and there is no need to save all policy content in the log, what do you think?


```
(current)
Time =  about 4s
CPU = 100%
```

```
(after this change)
Time = about 200 ms
CPU = 2%
```



