### PR TITLE
fix: fix `luaposix` build error

### DIFF
--- a/casbin-1.41.1-1.rockspec
+++ b/casbin-1.41.1-1.rockspec
@@ -18,7 +18,7 @@ dependencies = {
    "lua >= 5.1",
    "lualogging >= 1.5.1",
    "lrexlib-pcre >= 2.9.1",
-   "luaposix >= 35.0"
+   "luaposix = 35.1-1"
 }
 build = {
    type = "builtin",


### PR DESCRIPTION
Currently [`luaposix`](https://luarocks.org/modules/gvvaughan/luaposix) has released version [`36.0-1`](https://luarocks.org/modules/gvvaughan/luaposix/36.0-1) which causes build errors, this PR uses a fixed version to fix it.