### PR TITLE
fix: rockspec url protocol

### DIFF
--- a/.github/luarocks-template.rockspec
+++ b/.github/luarocks-template.rockspec
@@ -1,6 +1,6 @@
 package = "casbin"
 source = {
-   url = "git://github.com/casbin/lua-casbin",
+   url = "https://github.com/casbin/lua-casbin",
 }
 description = {
    summary = "An authorization library that supports access control models like ACL, RBAC, ABAC in Lua (OpenResty)",


### PR DESCRIPTION
The `git://` protocol seems to be failing since it has been deprecated by GitHub (https://github.blog/2021-09-01-improving-git-protocol-security-github/). Replacing it with `https` instead.