### PR TITLE
fix: Revert 146 fix protocol and fix rockspec

### DIFF
--- a/.github/luarocks-template.rockspec
+++ b/.github/luarocks-template.rockspec
@@ -1,6 +1,6 @@
 package = "casbin"
 source = {
-   url = "https://github.com/casbin/lua-casbin",
+   url = "git://github.com/casbin/lua-casbin",
 }
 description = {
    summary = "An authorization library that supports access control models like ACL, RBAC, ABAC in Lua (OpenResty)",

--- a/.github/luarocks-template.rockspec
+++ b/.github/luarocks-template.rockspec
@@ -1,6 +1,6 @@
 package = "casbin"
 source = {
-   url = "git://github.com/casbin/lua-casbin",
+   url = "git+https://github.com/casbin/lua-casbin.git",
 }
 description = {
    summary = "An authorization library that supports access control models like ACL, RBAC, ABAC in Lua (OpenResty)",


### PR DESCRIPTION
The `https` thing doesn't work directly (https://github.com/luarocks/luarocks/issues/826), fixed it now. Tested it locally, this should now hopefully work.