### PR TITLE
feat: switch to "luajit-openresty" to fix CI error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up Lua ${{ matrix.lua-version }}
-      uses: leafo/gh-actions-lua@v8.0.0
+      uses: leafo/gh-actions-lua@v10.0.0
       with:
         luaVersion: ${{ matrix.lua-version }}
 
@@ -94,7 +94,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Set up LuaJIT
-      uses: leafo/gh-actions-lua@v8.0.0
+      uses: leafo/gh-actions-lua@v10.0.0
       with:
         luaVersion: "luajit"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        lua-version: ["5.1", "5.2", "5.3", "5.4", "luajit"]
+        lua-version: ["5.1", "5.2", "5.3", "5.4", "luajit-openresty"]
 
     name: Lua ${{ matrix.lua-version }}
 
@@ -96,7 +96,7 @@ jobs:
     - name: Set up LuaJIT
       uses: leafo/gh-actions-lua@v10.0.0
       with:
-        luaVersion: "luajit"
+        luaVersion: "luajit-openresty"
 
     - name: Set up luarocks
       uses: leafo/gh-actions-luarocks@v4.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Lua ${{ matrix.lua-version }}
-        uses: leafo/gh-actions-lua@v8.0.0
+        uses: leafo/gh-actions-lua@v10.0.0
         with:
           luaVersion: 5.1
 


### PR DESCRIPTION
I changed the LuaJIT version from "luajit" to "luajit-openresty" which uses [openresty/luajit2](https://github.com/openresty/luajit2). This is a "fork" of the official LuaJIT, which is actively maintained and synchronized with the main branch and includes some ehancements, described under [OpenResty extensions](https://github.com/openresty/luajit2?tab=readme-ov-file#openresty-extensions).

Fixes: #160 